### PR TITLE
Add BrowserStack account registration and automatic reset

### DIFF
--- a/app/api/reset/route.ts
+++ b/app/api/reset/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { adminDb } from "@/lib/firebase/admin";
+
+const ACCOUNTS_COLLECTION = "browserstackAccounts";
+const LOGS_COLLECTION = "accountLogs";
+
+export async function POST() {
+  try {
+    const busySnapshot = await adminDb
+      .collection(ACCOUNTS_COLLECTION)
+      .where("status", "==", "busy")
+      .get();
+
+    if (busySnapshot.empty) {
+      return NextResponse.json({ reset: 0, at: new Date().toISOString() });
+    }
+
+    const batch = adminDb.batch();
+    const now = new Date().toISOString();
+
+    const logPayloads = busySnapshot.docs.map((doc) => {
+      const ref = doc.ref;
+      batch.update(ref, {
+        status: "free",
+        owner: null,
+        ownerId: null,
+        lastReturnedAt: now,
+      });
+
+      return {
+        accountId: doc.id,
+        action: "checkin" as const,
+        userId: "system-reset",
+        userName: "Reset automático",
+        email: null,
+        timestamp: now,
+      };
+    });
+
+    await batch.commit();
+
+    await Promise.all(
+      logPayloads.map(async (payload) => {
+        await adminDb.collection(LOGS_COLLECTION).add(payload);
+        await adminDb
+          .collection(`${ACCOUNTS_COLLECTION}/${payload.accountId}/history`)
+          .add(payload);
+      })
+    );
+
+    return NextResponse.json({ reset: logPayloads.length, at: now });
+  } catch (error) {
+    console.error("Erro ao executar reset automático", error);
+    return NextResponse.json({ message: "Erro interno" }, { status: 500 });
+  }
+}

--- a/components/dashboard/AccountList.tsx
+++ b/components/dashboard/AccountList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { formatRelative, parseISO } from "date-fns";
+import { format, formatRelative, parseISO } from "date-fns";
 import { ptBR } from "date-fns/locale";
 import { reserveAccount, releaseAccount, fetchAccountHistory } from "@/lib/firestore";
 import type { Account, AccountHistoryEntry } from "@/lib/types";
@@ -94,7 +94,7 @@ export function AccountList({ accounts, isLoading, error }: AccountListProps) {
               </span>
             </header>
 
-            <dl className="mt-4 grid gap-3 text-sm text-slate-500 md:grid-cols-3">
+            <dl className="mt-4 grid gap-3 text-sm text-slate-500 md:grid-cols-2 lg:grid-cols-5">
               <div>
                 <dt className="font-medium text-slate-600">Responsável</dt>
                 <dd>{account.owner ?? "-"}</dd>
@@ -105,6 +105,24 @@ export function AccountList({ accounts, isLoading, error }: AccountListProps) {
                   {account.lastUsedAt
                     ? formatRelative(parseISO(account.lastUsedAt), new Date(), { locale: ptBR })
                     : "Nunca"}
+                </dd>
+              </div>
+              <div>
+                <dt className="font-medium text-slate-600">Última devolução</dt>
+                <dd>
+                  {account.lastReturnedAt
+                    ? formatRelative(parseISO(account.lastReturnedAt), new Date(), { locale: ptBR })
+                    : "-"}
+                </dd>
+              </div>
+              <div>
+                <dt className="font-medium text-slate-600">Senha</dt>
+                <dd className="font-mono text-slate-700">
+                  {account.password
+                    ? isBusy && !isOwner
+                      ? "Em uso"
+                      : account.password
+                    : "-"}
                 </dd>
               </div>
               <div>
@@ -151,7 +169,11 @@ export function AccountList({ accounts, isLoading, error }: AccountListProps) {
                       </span>
                       <span>
                         {entry.timestamp
-                          ? formatRelative(new Date(entry.timestamp), new Date(), { locale: ptBR })
+                          ? `${format(new Date(entry.timestamp), "dd/MM/yyyy", { locale: ptBR })} às ${format(
+                              new Date(entry.timestamp),
+                              "HH:mm",
+                              { locale: ptBR }
+                            )}`
                           : "-"}
                       </span>
                     </li>

--- a/components/dashboard/AccountRegistrationForm.tsx
+++ b/components/dashboard/AccountRegistrationForm.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+
+import { createAccount } from "@/lib/firestore";
+import { PrimaryButton } from "@/components/ui/PrimaryButton";
+import { TextInput } from "@/components/ui/TextInput";
+
+export function AccountRegistrationForm() {
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!username || !email || !password) {
+      setError("Preencha todos os campos para cadastrar uma nova conta.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      await createAccount({ username, email, password });
+      setSuccess(`Conta ${username} adicionada com sucesso.`);
+      setUsername("");
+      setEmail("");
+      setPassword("");
+    } catch (err) {
+      console.error(err);
+      setError((err as Error).message ?? "Erro ao cadastrar conta.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <header className="space-y-1">
+        <h2 className="text-lg font-semibold text-slate-900">Cadastrar conta</h2>
+        <p className="text-sm text-slate-500">
+          Registre rapidamente novas credenciais do BrowserStack informando usuário, e-mail e senha.
+        </p>
+      </header>
+
+      <form onSubmit={handleSubmit} className="mt-4 space-y-3">
+        <TextInput
+          label="Usuário"
+          name="username"
+          placeholder="ex: qa-team-01"
+          value={username}
+          onChange={(event) => setUsername(event.target.value)}
+        />
+        <TextInput
+          type="email"
+          label="E-mail"
+          name="email"
+          placeholder="conta@empresa.com"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+        />
+        <TextInput
+          type="text"
+          label="Senha"
+          name="password"
+          placeholder="Senha do BrowserStack"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+        />
+        <PrimaryButton type="submit" disabled={isSubmitting} className="w-full">
+          {isSubmitting ? "Salvando..." : "Adicionar conta"}
+        </PrimaryButton>
+      </form>
+
+      {success && <p className="mt-3 text-xs text-emerald-700">{success}</p>}
+      {error && <p className="mt-3 text-xs text-rose-600">{error}</p>}
+    </section>
+  );
+}

--- a/components/dashboard/QuickReservationCard.tsx
+++ b/components/dashboard/QuickReservationCard.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { format, parseISO } from "date-fns";
+import { ptBR } from "date-fns/locale";
+import type { User } from "firebase/auth";
+
+import type { Account } from "@/lib/types";
+import { reserveAccount, releaseAccount } from "@/lib/firestore";
+import { PrimaryButton } from "@/components/ui/PrimaryButton";
+
+interface QuickReservationCardProps {
+  accounts: Account[] | undefined;
+  isLoading: boolean;
+  user: User | null;
+}
+
+export function QuickReservationCard({ accounts, isLoading, user }: QuickReservationCardProps) {
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isReserving, setIsReserving] = useState(false);
+  const [isReleasing, setIsReleasing] = useState(false);
+
+  const activeAccount = useMemo(() => {
+    if (!accounts || !user) return undefined;
+    return accounts.find((account) => account.status === "busy" && account.ownerId === user.uid);
+  }, [accounts, user]);
+
+  const formattedPickup = useMemo(() => {
+    if (!activeAccount?.lastUsedAt) return "-";
+    try {
+      return format(parseISO(activeAccount.lastUsedAt), "HH:mm", { locale: ptBR });
+    } catch (err) {
+      return "-";
+    }
+  }, [activeAccount?.lastUsedAt]);
+
+  const handleReserve = async () => {
+    if (!user) {
+      setError("Faça login para reservar uma conta.");
+      return;
+    }
+    if (!accounts || isLoading) {
+      return;
+    }
+    if (activeAccount) {
+      setError("Você já está com uma conta reservada. Libere antes de pegar outra.");
+      return;
+    }
+
+    const freeAccounts = accounts.filter((account) => account.status === "free");
+    if (freeAccounts.length === 0) {
+      setError("Nenhuma conta livre no momento.");
+      return;
+    }
+
+    const selectedAccount = freeAccounts[Math.floor(Math.random() * freeAccounts.length)];
+
+    setIsReserving(true);
+    setError(null);
+    try {
+      await reserveAccount(selectedAccount.id, {
+        uid: user.uid,
+        displayName: user.displayName,
+        email: user.email,
+      });
+      const now = format(new Date(), "HH:mm", { locale: ptBR });
+      setFeedback(`Conta ${selectedAccount.username} reservada às ${now}. Senha: ${selectedAccount.password ?? "-"}.`);
+    } catch (err) {
+      console.error(err);
+      setError((err as Error).message ?? "Erro ao reservar conta.");
+    } finally {
+      setIsReserving(false);
+    }
+  };
+
+  const handleRelease = async () => {
+    if (!user || !activeAccount) {
+      return;
+    }
+    setIsReleasing(true);
+    setError(null);
+    try {
+      await releaseAccount(activeAccount.id, {
+        uid: user.uid,
+        displayName: user.displayName,
+        email: user.email,
+      });
+      const now = format(new Date(), "HH:mm", { locale: ptBR });
+      setFeedback(`Conta ${activeAccount.username} liberada às ${now}.`);
+    } catch (err) {
+      console.error(err);
+      setError((err as Error).message ?? "Erro ao liberar conta.");
+    } finally {
+      setIsReleasing(false);
+    }
+  };
+
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <header className="space-y-1">
+        <h2 className="text-lg font-semibold text-slate-900">Uso rápido</h2>
+        <p className="text-sm text-slate-500">
+          Clique em "Pegar conta" para receber automaticamente uma credencial livre. O horário de retirada e devolução é salvo
+          no histórico.
+        </p>
+      </header>
+
+      <div className="mt-4 space-y-4">
+        {activeAccount ? (
+          <div className="rounded-xl bg-slate-50 p-4 text-sm text-slate-600">
+            <p>
+              <span className="font-semibold text-slate-700">Conta em uso:</span> {activeAccount.username}
+            </p>
+            <p className="font-mono text-slate-700">{activeAccount.email}</p>
+            {activeAccount.password && (
+              <p className="font-mono text-primary-600">Senha: {activeAccount.password}</p>
+            )}
+            <p>
+              Pegou às <span className="font-medium">{formattedPickup}</span>
+            </p>
+          </div>
+        ) : (
+          <p className="rounded-xl bg-emerald-50 p-4 text-sm text-emerald-700">
+            Nenhuma conta reservada. Clique abaixo para pegar a próxima disponível.
+          </p>
+        )}
+
+        <div className="flex flex-wrap gap-2">
+          <PrimaryButton onClick={handleReserve} disabled={isReserving || isLoading}>
+            {isReserving ? "Buscando..." : "Pegar conta"}
+          </PrimaryButton>
+          <button
+            onClick={handleRelease}
+            disabled={!activeAccount || isReleasing}
+            className="rounded-lg border border-slate-200 px-3 py-2 text-xs font-medium text-slate-600 hover:border-primary-200 hover:text-primary-600 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isReleasing ? "Liberando..." : "Devolver conta"}
+          </button>
+        </div>
+
+        {feedback && <p className="text-xs text-emerald-700">{feedback}</p>}
+        {error && <p className="text-xs text-rose-600">{error}</p>}
+      </div>
+    </section>
+  );
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,10 +4,12 @@ export interface Account {
   id: string;
   username: string;
   email: string;
+  password?: string | null;
   status: AccountStatus;
   owner?: string | null;
   ownerId?: string | null;
   lastUsedAt?: string | null;
+  lastReturnedAt?: string | null;
   history?: AccountHistoryEntry[];
 }
 


### PR DESCRIPTION
## Summary
- add quick reservation card to distribute free BrowserStack accounts randomly and show checkout/return times
- allow registering new BrowserStack credentials directly from the dashboard and persist passwords
- create an automatic reset endpoint and client-side trigger to release busy accounts daily at 18:00, logging the action
- enrich account list with password visibility, return timestamps, and formatted history entries

## Testing
- npm install *(fails: registry access blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfefc61348327b9e63d45840dc4fb