### PR TITLE
feat: redesign landing with dual theme support

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,16 +5,46 @@
 
 :root {
   color-scheme: light;
+  --background: 244 247 250;
+  --surface: 255 255 255;
+  --surface-elevated: 246 249 254;
+  --foreground: 15 23 42;
+  --muted: 90 104 126;
+  --border: 213 223 235;
 }
 
-body {
-  @apply bg-slate-50 text-slate-900;
+.dark {
+  color-scheme: dark;
+  --background: 7 12 22;
+  --surface: 12 19 33;
+  --surface-elevated: 17 27 45;
+  --foreground: 233 240 247;
+  --muted: 158 173 199;
+  --border: 62 78 107;
 }
 
-a {
-  @apply text-primary-600 hover:text-primary-700;
+@layer base {
+  body {
+    @apply bg-background text-foreground antialiased transition-colors duration-300;
+  }
+
+  a {
+    @apply text-brand-teal transition-colors duration-150 hover:text-brand-mint;
+  }
+
+  button {
+    @apply focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-teal focus-visible:ring-offset-2 focus-visible:ring-offset-background;
+  }
 }
 
-button {
-  @apply focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500;
+@layer utilities {
+  .bg-soft-grid {
+    background-image: linear-gradient(
+        to right,
+        rgb(var(--border) / 0.12) 1px,
+        transparent 1px
+      ),
+      linear-gradient(to bottom, rgb(var(--border) / 0.12) 1px, transparent 1px);
+    background-size: 40px 40px;
+  }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,8 +16,8 @@ export default async function RootLayout({
   await ensureDefaultAdmin();
 
   return (
-    <html lang="pt-BR">
-      <body className="min-h-screen bg-slate-100">
+    <html lang="pt-BR" suppressHydrationWarning>
+      <body className="min-h-screen bg-background font-sans">
         <AuthProvider>{children}</AuthProvider>
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { useAuth } from "@/hooks/useAuth";
 import { LoginForm } from "@/components/auth/LoginForm";
+import { ThemeToggle } from "@/components/ui/ThemeToggle";
 
 export default function HomePage() {
   const { user, loading } = useAuth();
@@ -23,17 +24,112 @@ export default function HomePage() {
     );
   }
 
+  const features = [
+    {
+      title: "Reservas inteligentes",
+      description: "Visualize rapidamente quem está usando as licenças e antecipe conflitos com alertas automáticos.",
+      gradient: "from-brand-teal/20 to-brand-mint/10",
+      text: "text-brand-teal"
+    },
+    {
+      title: "Fluxo colaborativo",
+      description: "Convide times, distribua acessos e acompanhe status com um painel intuitivo e responsivo.",
+      gradient: "from-brand-amber/25 to-brand-terracotta/10",
+      text: "text-brand-amber dark:text-brand-peach"
+    },
+    {
+      title: "Insights em tempo real",
+      description: "Monitoramento contínuo de reservas, devoluções e bloqueios para decisões baseadas em dados.",
+      gradient: "from-brand-leaf/20 to-brand-lime/10",
+      text: "text-brand-leaf"
+    },
+    {
+      title: "Segurança corporativa",
+      description: "Autenticação e redefinição de senha com proteção reforçada e rastreabilidade.",
+      gradient: "from-brand-olive/25 to-brand-teal/10",
+      text: "text-brand-olive"
+    }
+  ];
+
+  const badges = [
+    "Dark & Light mode automáticos",
+    "Interface responsiva",
+    "Paleta QA exclusiva"
+  ];
+
   return (
-    <main className="flex min-h-screen items-center justify-center px-4">
-      <div className="w-full max-w-md rounded-2xl bg-white p-8 shadow-xl">
-        <div className="space-y-6">
-          <header className="text-center">
-            <h1 className="text-3xl font-semibold text-slate-900">QA Manager</h1>
-            <p className="mt-2 text-sm text-slate-500">
-              Faça login para gerenciar as contas do BrowserStack.
-            </p>
-          </header>
-          <LoginForm />
+    <main className="relative isolate flex min-h-screen flex-col justify-center overflow-hidden px-4 py-16 sm:px-6 lg:px-12">
+      <div className="pointer-events-none absolute inset-0 -z-30 bg-soft-grid opacity-50 [mask-image:radial-gradient(ellipse_at_center,rgba(0,0,0,0.9)_0%,transparent_70%)]" />
+      <div className="absolute -left-32 top-24 -z-20 h-80 w-80 rounded-full bg-brand-teal/20 blur-3xl dark:bg-brand-mint/20" />
+      <div className="absolute -right-24 bottom-16 -z-20 h-96 w-96 rounded-full bg-brand-amber/25 blur-3xl dark:bg-brand-olive/25" />
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-12">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-3 rounded-full border border-border/60 bg-surface/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-muted shadow-sm backdrop-blur">
+            <span className="h-2.5 w-2.5 rounded-full bg-brand-teal" />
+            <span>Quality Digital</span>
+          </div>
+          <ThemeToggle />
+        </div>
+
+        <div className="grid gap-12 lg:grid-cols-[1.05fr_1fr] lg:items-center">
+          <section className="space-y-10 text-balance">
+            <div className="space-y-6">
+              <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-surface-elevated/80 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-brand-teal shadow-sm">
+                Novo visual
+              </span>
+              <div className="space-y-4">
+                <h1 className="text-4xl font-bold leading-tight text-foreground sm:text-5xl">
+                  Um layout dinâmico para acelerar a gestão do BrowserStack
+                </h1>
+                <p className="text-lg text-muted">
+                  Modernizamos o QA Manager com uma experiência elegante, centrada no fluxo do time e pronta para o modo claro ou escuro.
+                </p>
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              {features.map((feature) => (
+                <article
+                  key={feature.title}
+                  className="group relative overflow-hidden rounded-2xl border border-border/60 bg-surface/90 p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-xl"
+                >
+                  <div className={`absolute inset-0 -z-10 bg-gradient-to-br ${feature.gradient}`} aria-hidden="true" />
+                  <h3 className={`text-base font-semibold ${feature.text}`}>{feature.title}</h3>
+                  <p className="mt-2 text-sm text-muted">{feature.description}</p>
+                </article>
+              ))}
+            </div>
+
+            <div className="flex flex-wrap gap-3 text-sm text-muted">
+              {badges.map((badge) => (
+                <span
+                  key={badge}
+                  className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-surface-elevated/80 px-4 py-2 font-medium text-foreground/80 shadow-sm"
+                >
+                  <span className="h-2 w-2 rounded-full bg-brand-mint" />
+                  {badge}
+                </span>
+              ))}
+            </div>
+          </section>
+
+          <section className="relative">
+            <div className="absolute inset-0 -z-10 rounded-3xl bg-gradient-to-br from-brand-teal/25 via-brand-mint/10 to-brand-amber/25 blur-2xl" aria-hidden="true" />
+            <div className="relative rounded-3xl border border-border/60 bg-surface/90 p-8 shadow-2xl shadow-brand-teal/10 backdrop-blur-xl dark:border-border/40 dark:bg-surface/80">
+              <header className="space-y-3 text-center lg:text-left">
+                <span className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-brand-teal">
+                  Acesso seguro
+                </span>
+                <h2 className="text-2xl font-semibold text-foreground">QA Manager</h2>
+                <p className="text-sm text-muted">
+                  Faça login com seu e-mail corporativo e organize os testes no BrowserStack sem fricções.
+                </p>
+              </header>
+              <div className="mt-8">
+                <LoginForm />
+              </div>
+            </div>
+          </section>
         </div>
       </div>
     </main>

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -86,9 +86,9 @@ export function LoginForm() {
           required
         />
         {(error || (mode === "login" && authError)) && (
-          <p className="text-sm text-rose-600">{error ?? authError}</p>
+          <p className="text-sm text-brand-terracotta">{error ?? authError}</p>
         )}
-        {info && <p className="text-sm text-emerald-700">{info}</p>}
+        {info && <p className="text-sm text-brand-mint">{info}</p>}
         <PrimaryButton type="submit" className="w-full" disabled={loading}>
           {loading ? "Processando..." : mode === "login" ? "Entrar" : "Criar conta"}
         </PrimaryButton>
@@ -99,17 +99,17 @@ export function LoginForm() {
           type="button"
           onClick={handlePasswordReset}
           disabled={resetLoading}
-          className="w-full text-center text-xs font-medium text-primary-600 hover:text-primary-700 disabled:opacity-60"
+          className="w-full text-center text-xs font-semibold text-brand-teal transition hover:text-brand-mint disabled:opacity-60"
         >
           {resetLoading ? "Enviando..." : "Esqueceu a senha?"}
         </button>
       )}
 
-      <p className="text-center text-xs text-slate-500">
+      <p className="text-center text-xs text-muted">
         {mode === "login" ? "Ainda não tem acesso?" : "Já possui uma conta?"}{" "}
         <button
           type="button"
-          className="font-medium text-primary-600 hover:text-primary-700"
+          className="font-semibold text-brand-teal hover:text-brand-mint"
           onClick={() => {
             setMode(mode === "login" ? "register" : "login");
             setError(null);

--- a/components/ui/PrimaryButton.tsx
+++ b/components/ui/PrimaryButton.tsx
@@ -4,7 +4,7 @@ import clsx from "clsx";
 import { ButtonHTMLAttributes } from "react";
 
 const baseStyles =
-  "inline-flex items-center justify-center rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 disabled:cursor-not-allowed disabled:opacity-70";
+  "inline-flex items-center justify-center rounded-xl bg-gradient-to-r from-brand-teal via-brand-mint to-brand-lime px-4 py-2.5 text-sm font-semibold text-white shadow-lg shadow-brand-teal/20 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-teal disabled:cursor-not-allowed disabled:opacity-70 hover:brightness-105 dark:from-brand-mint dark:via-brand-leaf dark:to-brand-lime";
 
 export function PrimaryButton({ className, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
   return <button className={clsx(baseStyles, className)} {...props} />;

--- a/components/ui/TextInput.tsx
+++ b/components/ui/TextInput.tsx
@@ -11,17 +11,17 @@ interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
 export function TextInput({ label, helperText, className, id, ...props }: TextInputProps) {
   const inputId = id ?? props.name ?? `input-${label?.toLowerCase().replace(/\s+/g, "-") ?? crypto.randomUUID()}`;
   return (
-    <label className="block space-y-1 text-sm text-slate-600" htmlFor={inputId}>
-      {label && <span className="font-medium text-slate-700">{label}</span>}
+    <label className="block space-y-1 text-sm text-muted" htmlFor={inputId}>
+      {label && <span className="font-medium text-foreground/80 dark:text-foreground">{label}</span>}
       <input
         id={inputId}
         className={clsx(
-          "w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200",
+          "w-full rounded-xl border border-border/60 bg-surface-elevated/80 px-3.5 py-2.5 text-sm text-foreground shadow-sm transition placeholder:text-muted/70 focus:border-brand-teal focus:outline-none focus:ring-4 focus:ring-brand-teal/20 dark:border-border/40 dark:bg-surface-elevated/70 dark:focus:border-brand-mint dark:focus:ring-brand-mint/25",
           className
         )}
         {...props}
       />
-      {helperText && <span className="text-xs text-slate-400">{helperText}</span>}
+      {helperText && <span className="text-xs text-muted/80">{helperText}</span>}
     </label>
   );
 }

--- a/components/ui/ThemeToggle.tsx
+++ b/components/ui/ThemeToggle.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "qa-theme";
+
+type ThemeMode = "light" | "dark";
+
+const sunIcon = (
+  <svg
+    aria-hidden="true"
+    viewBox="0 0 24 24"
+    className="h-5 w-5 fill-none stroke-current"
+  >
+    <circle cx="12" cy="12" r="4" strokeWidth="1.5" />
+    <path strokeWidth="1.5" strokeLinecap="round" d="M12 3v2m0 14v2m9-9h-2M5 12H3m15.364-6.364-1.414 1.414M7.05 16.95l-1.414 1.414m12.728 0-1.414-1.414M7.05 7.05 5.636 5.636" />
+  </svg>
+);
+
+const moonIcon = (
+  <svg
+    aria-hidden="true"
+    viewBox="0 0 24 24"
+    className="h-5 w-5 fill-none stroke-current"
+  >
+    <path
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M21 12.79A9 9 0 1 1 11.21 3c.2-.01.39.09.5.26a.6.6 0 0 1-.05.72 6.5 6.5 0 0 0 8.36 9.11.6.6 0 0 1 .72-.05.53.53 0 0 1 .26.5Z"
+    />
+  </svg>
+);
+
+export function ThemeToggle() {
+  const [mounted, setMounted] = useState(false);
+  const [theme, setTheme] = useState<ThemeMode>("light");
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const stored = window.localStorage.getItem(STORAGE_KEY) as ThemeMode | null;
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const initial = stored ?? (prefersDark ? "dark" : "light");
+    root.classList.toggle("dark", initial === "dark");
+    root.dataset.theme = initial;
+    setTheme(initial);
+    setMounted(true);
+  }, []);
+
+  const toggleTheme = () => {
+    setTheme((current) => {
+      const next: ThemeMode = current === "dark" ? "light" : "dark";
+      const root = document.documentElement;
+      root.classList.toggle("dark", next === "dark");
+      root.dataset.theme = next;
+      window.localStorage.setItem(STORAGE_KEY, next);
+      return next;
+    });
+  };
+
+  if (!mounted) {
+    return (
+      <div className="h-10 w-10 rounded-full border border-border/50 bg-surface-elevated/80" />
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-pressed={theme === "dark"}
+      className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border/60 bg-surface-elevated/80 text-foreground shadow-sm transition hover:border-brand-teal/60 hover:text-brand-teal focus-visible:ring-brand-teal/60 dark:hover:border-brand-mint/50 dark:hover:text-brand-mint"
+    >
+      <span className="sr-only">Alternar entre modo claro e escuro</span>
+      {theme === "dark" ? moonIcon : sunIcon}
+    </button>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+  darkMode: "class",
   content: [
     "./app/**/*.{js,ts,jsx,tsx}",
     "./components/**/*.{js,ts,jsx,tsx}",
@@ -9,17 +10,23 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        primary: {
-          50: "#f2f5ff",
-          100: "#e0e7ff",
-          200: "#c7d2fe",
-          300: "#a5b4fc",
-          400: "#818cf8",
-          500: "#6366f1",
-          600: "#4f46e5",
-          700: "#4338ca",
-          800: "#3730a3",
-          900: "#312e81"
+        background: "rgb(var(--background) / <alpha-value>)",
+        surface: {
+          DEFAULT: "rgb(var(--surface) / <alpha-value>)",
+          elevated: "rgb(var(--surface-elevated) / <alpha-value>)"
+        },
+        foreground: "rgb(var(--foreground) / <alpha-value>)",
+        muted: "rgb(var(--muted) / <alpha-value>)",
+        border: "rgb(var(--border) / <alpha-value>)",
+        brand: {
+          lime: "#A7C63D",
+          terracotta: "#E06D3C",
+          teal: "#1AA6B7",
+          peach: "#E9A99B",
+          mint: "#56B88C",
+          amber: "#F2B75C",
+          leaf: "#63B05B",
+          olive: "#9F8E3F"
         }
       }
     }


### PR DESCRIPTION
## Summary
- add a brand color system and CSS variables to support both light and dark palettes
- redesign the login landing layout with feature highlights, gradients, and palette-driven styling
- create a reusable theme toggle and refresh form components to match the new visual direction

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc1898c82c83279d901a2561baf2a7