### PR TITLE
feat: enhance admin dashboard analytics

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -18,6 +18,7 @@ export default function DashboardPage() {
   );
   const { accounts, isLoading, error } = useAccounts();
   const [redirecting, setRedirecting] = useState(false);
+  const isAdmin = role === "admin";
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -103,9 +104,15 @@ export default function DashboardPage() {
           />
         </div>
         <div className="space-y-4">
-          <QuickReservationCard accounts={accounts} isLoading={isLoading} user={user} />
-          {role === "admin" && <AccountRegistrationForm />}
-          {role === "admin" && accounts && <AdminUsageInsights accounts={accounts} />}
+          {!isAdmin && (
+            <QuickReservationCard
+              accounts={accounts}
+              isLoading={isLoading}
+              user={user}
+            />
+          )}
+          {isAdmin && <AccountRegistrationForm />}
+          {isAdmin && accounts && <AdminUsageInsights accounts={accounts} />}
         </div>
       </section>
     </main>

--- a/components/dashboard/AdminUsageInsights.tsx
+++ b/components/dashboard/AdminUsageInsights.tsx
@@ -1,15 +1,59 @@
 "use client";
 
 import { useMemo } from "react";
-import { format, parseISO } from "date-fns";
+import type { ReactNode } from "react";
+import {
+  differenceInCalendarDays,
+  format,
+  isToday,
+  parseISO,
+} from "date-fns";
 import { ptBR } from "date-fns/locale";
 
 import type { Account } from "@/lib/types";
 import { useAccountLogs } from "@/hooks/useAccountLogs";
 import { PrimaryButton } from "@/components/ui/PrimaryButton";
+import { PieChart } from "@/components/dashboard/PieChart";
+
+const ACCOUNT_PALETTE = [
+  "#2563eb",
+  "#7c3aed",
+  "#f97316",
+  "#14b8a6",
+  "#ec4899",
+  "#22c55e",
+] as const;
 
 interface AdminUsageInsightsProps {
   accounts: Account[];
+}
+
+interface LegendItem {
+  label: string;
+  value: number;
+  color: string;
+  percentage: number;
+}
+
+function safeParseTimestamp(timestamp: string | null | undefined) {
+  if (!timestamp) return null;
+  try {
+    return parseISO(timestamp);
+  } catch (error) {
+    console.warn("Timestamp inválido detectado", error);
+    return null;
+  }
+}
+
+function buildLegend(data: { label: string; value: number; color: string }[]) {
+  const total = data.reduce((sum, item) => sum + item.value, 0);
+  if (total === 0) {
+    return data.map((item) => ({ ...item, percentage: 0 }));
+  }
+  return data.map((item) => ({
+    ...item,
+    percentage: Math.round((item.value / total) * 100),
+  }));
 }
 
 export function AdminUsageInsights({ accounts }: AdminUsageInsightsProps) {
@@ -22,20 +66,121 @@ export function AdminUsageInsights({ accounts }: AdminUsageInsightsProps) {
     }, {});
   }, [accounts]);
 
-  const ranking = useMemo(() => {
+  const reservationLogs = useMemo(
+    () => logs.filter((log) => log.action === "checkout"),
+    [logs]
+  );
+
+  const statusSummary = useMemo(() => {
+    const busy = accounts.filter((account) => account.status === "busy").length;
+    const total = accounts.length;
+    const free = total - busy;
+    const occupancy = total > 0 ? Math.round((busy / total) * 100) : 0;
+    return { busy, free, total, occupancy };
+  }, [accounts]);
+
+  const summaryStats = useMemo(() => {
+    const today = reservationLogs.filter((log) => {
+      const parsed = safeParseTimestamp(log.timestamp);
+      return parsed ? isToday(parsed) : false;
+    }).length;
+
+    const lastSevenDays = reservationLogs.filter((log) => {
+      const parsed = safeParseTimestamp(log.timestamp);
+      if (!parsed) return false;
+      return differenceInCalendarDays(new Date(), parsed) <= 6;
+    }).length;
+
+    const uniqueUsers = new Set(
+      reservationLogs
+        .map((log) => log.email ?? log.userName ?? log.userId)
+        .filter(Boolean)
+    );
+
+    return {
+      today,
+      lastSevenDays,
+      uniqueUsers: uniqueUsers.size,
+      totalReservations: reservationLogs.length,
+    };
+  }, [reservationLogs]);
+
+  const userRanking = useMemo(() => {
     const counts = new Map<string, { total: number; label: string }>();
-    logs
-      .filter((log) => log.action === "checkout")
-      .forEach((log) => {
-        const label = log.email ?? log.userName ?? log.userId;
-        const key = label ?? log.userId;
-        if (!key) return;
-        const entry = counts.get(key) ?? { total: 0, label: label ?? log.userId };
-        entry.total += 1;
-        counts.set(key, entry);
-      });
+    reservationLogs.forEach((log) => {
+      const label = log.email ?? log.userName ?? log.userId;
+      const key = label ?? log.userId;
+      if (!key) return;
+      const entry = counts.get(key) ?? { total: 0, label: label ?? log.userId };
+      entry.total += 1;
+      counts.set(key, entry);
+    });
     return Array.from(counts.values()).sort((a, b) => b.total - a.total);
-  }, [logs]);
+  }, [reservationLogs]);
+
+  const usageByAccount = useMemo(() => {
+    const counter = new Map<
+      string,
+      { total: number; label: string; email?: string }
+    >();
+    reservationLogs.forEach((log) => {
+      const accountId = log.accountId;
+      const accountInfo = accountNames[accountId];
+      const entry =
+        counter.get(accountId) ?? {
+          total: 0,
+          label: accountInfo?.username ?? accountId,
+          email: accountInfo?.email,
+        };
+      entry.total += 1;
+      counter.set(accountId, entry);
+    });
+    return Array.from(counter.entries())
+      .map(([accountId, data]) => ({ accountId, ...data }))
+      .sort((a, b) => b.total - a.total);
+  }, [accountNames, reservationLogs]);
+
+  const statusSegments = useMemo(
+    () => [
+      { label: "Em uso", value: statusSummary.busy, color: "#f59e0b" },
+      { label: "Livres", value: statusSummary.free, color: "#10b981" },
+    ],
+    [statusSummary.busy, statusSummary.free]
+  );
+
+  const statusLegend = useMemo<LegendItem[]>(
+    () => buildLegend(statusSegments),
+    [statusSegments]
+  );
+
+  const accountSegments = useMemo(() => {
+    if (!reservationLogs.length) {
+      return [];
+    }
+
+    const topEntries = usageByAccount.slice(0, 5).map((entry, index) => ({
+      label: entry.label,
+      value: entry.total,
+      color: ACCOUNT_PALETTE[index % ACCOUNT_PALETTE.length],
+    }));
+
+    const usedTotal = topEntries.reduce((sum, item) => sum + item.value, 0);
+    const remainder = reservationLogs.length - usedTotal;
+    if (remainder > 0) {
+      topEntries.push({
+        label: "Outros",
+        value: remainder,
+        color: "#cbd5f5",
+      });
+    }
+
+    return topEntries;
+  }, [reservationLogs.length, usageByAccount]);
+
+  const accountLegend = useMemo<LegendItem[]>(
+    () => buildLegend(accountSegments),
+    [accountSegments]
+  );
 
   const historyByAccount = useMemo(() => {
     return logs.reduce<Record<string, typeof logs>>((acc, log) => {
@@ -46,12 +191,12 @@ export function AdminUsageInsights({ accounts }: AdminUsageInsightsProps) {
   }, [logs]);
 
   return (
-    <section className="space-y-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+    <section className="space-y-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-lg">
       <header className="flex flex-wrap items-center justify-between gap-3">
-        <div>
+        <div className="space-y-1">
           <h2 className="text-lg font-semibold text-slate-900">Visão administrativa</h2>
           <p className="text-sm text-slate-500">
-            Acompanhe o uso das contas e identifique os usuários mais ativos.
+            Acompanhe o pulso das reservas e identifique oportunidades de otimização.
           </p>
         </div>
         <PrimaryButton type="button" onClick={refresh} disabled={loading}>
@@ -59,103 +204,243 @@ export function AdminUsageInsights({ accounts }: AdminUsageInsightsProps) {
         </PrimaryButton>
       </header>
 
-      {error && <p className="text-sm text-rose-600">Erro ao carregar dados de uso.</p>}
+      {error && (
+        <p className="rounded-lg bg-rose-50 px-4 py-3 text-sm text-rose-600">
+          Erro ao carregar dados de uso.
+        </p>
+      )}
 
-      <div className="grid gap-6 lg:grid-cols-2">
-        <div>
-          <h3 className="text-sm font-semibold text-slate-700">Ranking de usuários</h3>
-          {ranking.length === 0 ? (
-            <p className="mt-3 text-xs text-slate-500">
-              {loading ? "Carregando ranking..." : "Nenhum uso registrado."}
-            </p>
-          ) : (
-            <ol className="mt-3 space-y-2 text-sm text-slate-600">
-              {ranking.map((entry, index) => (
-                <li
-                  key={entry.label}
-                  className="flex items-center justify-between rounded-lg bg-slate-50 px-3 py-2"
-                >
-                  <span>
-                    <span className="mr-2 rounded-full bg-primary-100 px-2 py-0.5 text-xs font-semibold text-primary-700">
-                      #{index + 1}
-                    </span>
-                    {entry.label}
-                  </span>
-                  <span className="text-xs text-slate-500">{entry.total} reservas</span>
-                </li>
-              ))}
-            </ol>
-          )}
+      <div className="grid gap-6">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <StatCard
+            title="Reservas hoje"
+            value={summaryStats.today}
+            helper="Registros de checkout nas últimas 24h"
+          />
+          <StatCard
+            title="Últimos 7 dias"
+            value={summaryStats.lastSevenDays}
+            helper="Reservas concluídas na última semana"
+          />
+          <StatCard
+            title="Usuários ativos"
+            value={summaryStats.uniqueUsers}
+            helper="Pessoas diferentes que reservaram"
+          />
+          <StatCard
+            title="Taxa de ocupação"
+            value={`${statusSummary.occupancy}%`}
+            helper={`${statusSummary.busy} de ${statusSummary.total} contas em uso`}
+          />
         </div>
 
-        <div>
-          <h3 className="text-sm font-semibold text-slate-700">Histórico geral</h3>
-          <div className="mt-3 max-h-72 space-y-2 overflow-auto pr-2 text-xs text-slate-600">
-            {loading && <p>Carregando histórico...</p>}
-            {!loading && logs.length === 0 && <p>Nenhum evento registrado.</p>}
-            {!loading &&
-              logs.map((log) => {
-                const timestamp = log.timestamp ? parseISO(log.timestamp) : null;
-                const accountInfo = accountNames[log.accountId];
-                const formattedDate = timestamp
-                  ? `${format(timestamp, "dd/MM/yyyy", { locale: ptBR })} às ${format(timestamp, "HH:mm", { locale: ptBR })}`
-                  : "-";
-                return (
-                  <div
-                    key={`${log.id}`}
-                    className="rounded-lg border border-slate-100 bg-slate-50 px-3 py-2"
-                  >
-                    <p className="font-medium text-slate-700">
-                      {log.action === "checkout" ? "Reserva" : "Devolução"} – {accountInfo?.username ?? log.accountId}
-                    </p>
-                    <p>
-                      Usuário: {log.email ?? log.userName ?? log.userId}
-                    </p>
-                    <p>
-                      Conta: {accountInfo?.email ?? "-"}
-                    </p>
-                    <p className="text-slate-500">{formattedDate}</p>
-                  </div>
-                );
-              })}
-          </div>
-        </div>
-      </div>
+        <div className="grid gap-6 xl:grid-cols-2">
+          <InsightPanel title="Status das contas" description="Distribuição atual das licenças cadastradas.">
+            <div className="flex flex-col items-center gap-4 md:flex-row">
+              <PieChart
+                data={statusSegments}
+                centralLabel={{
+                  title: "Total",
+                  value: String(statusSummary.total),
+                  subtitle: "contas",
+                }}
+              />
+              <LegendList items={statusLegend} emptyLabel="Nenhuma conta cadastrada." />
+            </div>
+          </InsightPanel>
 
-      <div>
-        <h3 className="text-sm font-semibold text-slate-700">Histórico por conta</h3>
-        <div className="mt-3 grid gap-3 md:grid-cols-2">
-          {accounts.map((account) => {
-            const accountHistory = historyByAccount[account.id] ?? [];
-            return (
-              <div key={account.id} className="rounded-xl border border-slate-100 bg-slate-50 p-4 text-xs text-slate-600">
-                <p className="font-semibold text-slate-700">{account.username}</p>
-                <p className="font-mono text-slate-500">{account.email}</p>
-                {accountHistory.length === 0 ? (
-                  <p className="mt-2 text-slate-500">Sem registros recentes.</p>
-                ) : (
-                  <ul className="mt-2 space-y-1">
-                    {accountHistory.slice(0, 5).map((entry) => {
-                      const timestamp = entry.timestamp ? parseISO(entry.timestamp) : null;
-                      const formatted = timestamp
-                        ? `${format(timestamp, "dd/MM", { locale: ptBR })} ${format(timestamp, "HH:mm", { locale: ptBR })}`
-                        : "-";
-                      return (
-                        <li key={entry.id} className="flex justify-between gap-2">
-                          <span className="font-medium text-slate-700">
-                            {entry.action === "checkout" ? "Reservado" : "Liberado"} por {entry.email ?? entry.userName ?? entry.userId}
-                          </span>
-                          <span className="text-slate-500">{formatted}</span>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                )}
+          <InsightPanel title="Contas mais acessadas" description="Como as reservas se distribuem entre as contas.">
+            {reservationLogs.length === 0 ? (
+              <EmptyState message={loading ? "Carregando dados de uso..." : "Nenhuma reserva registrada."} />
+            ) : (
+              <div className="flex flex-col items-center gap-4 md:flex-row">
+                <PieChart
+                  data={accountSegments}
+                  centralLabel={{
+                    title: "Reservas",
+                    value: String(summaryStats.totalReservations),
+                    subtitle: "registradas",
+                  }}
+                />
+                <LegendList items={accountLegend} emptyLabel="Nenhuma reserva registrada." />
               </div>
-            );
-          })}
+            )}
+          </InsightPanel>
         </div>
+
+        <div className="grid gap-6 lg:grid-cols-[1.2fr,1fr]">
+          <InsightPanel title="Ranking de usuários" description="Usuários que mais reservaram contas.">
+            {userRanking.length === 0 ? (
+              <EmptyState message={loading ? "Carregando ranking..." : "Nenhum uso registrado."} />
+            ) : (
+              <ol className="space-y-3 text-sm text-slate-600">
+                {userRanking.slice(0, 8).map((entry, index) => (
+                  <li
+                    key={entry.label}
+                    className="flex items-center justify-between rounded-xl bg-slate-50 px-4 py-3 shadow-inner"
+                  >
+                    <span className="flex items-center gap-3">
+                      <span className="flex h-7 w-7 items-center justify-center rounded-full bg-primary-100 text-xs font-semibold text-primary-700">
+                        #{index + 1}
+                      </span>
+                      {entry.label}
+                    </span>
+                    <span className="text-xs font-medium text-slate-500">
+                      {entry.total} reservas
+                    </span>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </InsightPanel>
+
+          <InsightPanel title="Visão cronológica" description="Eventos mais recentes registrados no sistema.">
+            <div className="max-h-72 space-y-3 overflow-auto pr-2 text-xs text-slate-600">
+              {loading && <p>Carregando histórico...</p>}
+              {!loading && logs.length === 0 && (
+                <p>Nenhum evento registrado.</p>
+              )}
+              {!loading &&
+                logs.map((log) => {
+                  const timestamp = safeParseTimestamp(log.timestamp);
+                  const accountInfo = accountNames[log.accountId];
+                  const formattedDate = timestamp
+                    ? `${format(timestamp, "dd/MM/yyyy", { locale: ptBR })} às ${format(timestamp, "HH:mm", { locale: ptBR })}`
+                    : "-";
+                  return (
+                    <div
+                      key={`${log.id}`}
+                      className="rounded-lg border border-slate-100 bg-white/60 px-3 py-2 shadow-sm"
+                    >
+                      <p className="font-medium text-slate-700">
+                        {log.action === "checkout" ? "Reserva" : "Devolução"} – {accountInfo?.username ?? log.accountId}
+                      </p>
+                      <p>Usuário: {log.email ?? log.userName ?? log.userId}</p>
+                      <p>Conta: {accountInfo?.email ?? "-"}</p>
+                      <p className="text-slate-500">{formattedDate}</p>
+                    </div>
+                  );
+                })}
+            </div>
+          </InsightPanel>
+        </div>
+
+        <InsightPanel title="Histórico por conta" description="Últimas movimentações de cada credencial.">
+          <div className="grid gap-3 md:grid-cols-2">
+            {accounts.map((account) => {
+              const accountHistory = historyByAccount[account.id] ?? [];
+              return (
+                <div key={account.id} className="rounded-xl border border-slate-100 bg-slate-50 p-4 text-xs text-slate-600">
+                  <p className="font-semibold text-slate-700">{account.username}</p>
+                  <p className="font-mono text-slate-500">{account.email}</p>
+                  {accountHistory.length === 0 ? (
+                    <p className="mt-2 text-slate-500">Sem registros recentes.</p>
+                  ) : (
+                    <ul className="mt-2 space-y-1">
+                      {accountHistory.slice(0, 5).map((entry) => {
+                        const timestamp = safeParseTimestamp(entry.timestamp);
+                        const formatted = timestamp
+                          ? `${format(timestamp, "dd/MM", { locale: ptBR })} ${format(timestamp, "HH:mm", { locale: ptBR })}`
+                          : "-";
+                        return (
+                          <li key={entry.id} className="flex justify-between gap-2">
+                            <span className="font-medium text-slate-700">
+                              {entry.action === "checkout" ? "Reservado" : "Liberado"} por {entry.email ?? entry.userName ?? entry.userId}
+                            </span>
+                            <span className="text-slate-500">{formatted}</span>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </InsightPanel>
       </div>
     </section>
+  );
+}
+
+function StatCard({
+  title,
+  value,
+  helper,
+}: {
+  title: string;
+  value: number | string;
+  helper: string;
+}) {
+  return (
+    <div className="rounded-2xl border border-slate-100 bg-slate-50 p-4 shadow-inner">
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+        {title}
+      </p>
+      <p className="mt-2 text-2xl font-semibold text-slate-900">{value}</p>
+      <p className="text-xs text-slate-500">{helper}</p>
+    </div>
+  );
+}
+
+function InsightPanel({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <header className="space-y-1">
+        <h3 className="text-sm font-semibold text-slate-700">{title}</h3>
+        <p className="text-xs text-slate-500">{description}</p>
+      </header>
+      {children}
+    </section>
+  );
+}
+
+function LegendList({
+  items,
+  emptyLabel,
+}: {
+  items: LegendItem[];
+  emptyLabel: string;
+}) {
+  if (!items.length) {
+    return <p className="text-xs text-slate-500">{emptyLabel}</p>;
+  }
+
+  return (
+    <ul className="w-full space-y-2 text-xs text-slate-600">
+      {items.map((item) => (
+        <li key={item.label} className="flex items-center justify-between gap-4">
+          <span className="flex items-center gap-2">
+            <span
+              className="h-3 w-3 rounded-full"
+              style={{ backgroundColor: item.color }}
+            />
+            {item.label}
+          </span>
+          <span className="font-medium text-slate-700">
+            {item.value}
+            <span className="ml-1 text-[0.65rem] font-normal text-slate-400">
+              {item.percentage}%
+            </span>
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <p className="rounded-lg border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-500">
+      {message}
+    </p>
   );
 }

--- a/components/dashboard/PieChart.tsx
+++ b/components/dashboard/PieChart.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import clsx from "clsx";
+
+export interface PieChartData {
+  label: string;
+  value: number;
+  color: string;
+}
+
+interface PieChartProps {
+  data: PieChartData[];
+  size?: number;
+  thickness?: number;
+  centralLabel?: {
+    title?: string;
+    value?: string;
+    subtitle?: string;
+  };
+  className?: string;
+}
+
+export function PieChart({
+  data,
+  size = 180,
+  thickness = 22,
+  centralLabel,
+  className,
+}: PieChartProps) {
+  const total = data.reduce((sum, segment) => sum + segment.value, 0);
+  const radius = size / 2 - thickness / 2;
+  const circumference = 2 * Math.PI * radius;
+  let cumulative = 0;
+  const showSegments = total > 0;
+
+  return (
+    <div
+      className={clsx("relative flex items-center justify-center", className)}
+      style={{ width: size, height: size }}
+    >
+      <svg
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        role="img"
+        aria-label="Gráfico de pizza"
+      >
+        <g transform={`rotate(-90 ${size / 2} ${size / 2})`}>
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            fill="transparent"
+            stroke="#e2e8f0"
+            strokeWidth={thickness}
+          />
+          {showSegments &&
+            data.map((segment) => {
+              const segmentLength =
+                total === 0 ? 0 : (segment.value / total) * circumference;
+              const dashArray = `${segmentLength} ${circumference}`;
+              const dashOffset = circumference - cumulative;
+              cumulative += segmentLength;
+              return (
+                <circle
+                  key={segment.label}
+                  cx={size / 2}
+                  cy={size / 2}
+                  r={radius}
+                  fill="transparent"
+                  stroke={segment.color}
+                  strokeWidth={thickness}
+                  strokeDasharray={dashArray}
+                  strokeDashoffset={dashOffset}
+                  strokeLinecap="butt"
+                />
+              );
+            })}
+        </g>
+      </svg>
+      {centralLabel && (
+        <div className="absolute flex flex-col items-center text-center">
+          {centralLabel.title && (
+            <span className="text-[0.65rem] uppercase tracking-wide text-slate-400">
+              {centralLabel.title}
+            </span>
+          )}
+          {centralLabel.value && (
+            <span className="text-xl font-semibold text-slate-900">
+              {centralLabel.value}
+            </span>
+          )}
+          {centralLabel.subtitle && (
+            <span className="text-[0.65rem] text-slate-400">
+              {centralLabel.subtitle}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- block administrators from creating reservations and hide the quick reservation shortcut for them
- redesign the admin insights panel with detailed stats, rankings, and donut charts for account usage
- add a reusable pie chart component to render the new visualizations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc28bb830c8327bd574865185f7928