### PR TITLE
Create compact login experience and admin account CRUD tools

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -87,7 +87,14 @@ export default function DashboardPage() {
   }
 
   return (
-    <main className="mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-4 py-10">
+    <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-6 px-4 py-8">
+      {!isAdmin && (
+        <QuickReservationCard
+          accounts={accounts}
+          isLoading={isLoading}
+          user={user}
+        />
+      )}
       <DashboardHeader
         onSignOut={signOut}
         statusFilter={statusFilter}
@@ -99,26 +106,31 @@ export default function DashboardPage() {
         user={user}
         role={role}
       />
-      <section className="grid gap-4 lg:grid-cols-[2fr,1fr]">
-        <div className="space-y-4">
+      {isAdmin ? (
+        <section className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+          <div className="space-y-4">
+            <AccountList
+              accounts={filteredAccounts}
+              isLoading={isLoading}
+              error={error}
+              role={role}
+            />
+          </div>
+          <div className="space-y-4">
+            {accounts && <AdminUsageInsights accounts={accounts} />}
+            <AccountRegistrationForm />
+          </div>
+        </section>
+      ) : (
+        <section className="space-y-4">
           <AccountList
             accounts={filteredAccounts}
             isLoading={isLoading}
             error={error}
+            role={role}
           />
-        </div>
-        <div className="space-y-4">
-          {!isAdmin && (
-            <QuickReservationCard
-              accounts={accounts}
-              isLoading={isLoading}
-              user={user}
-            />
-          )}
-          {isAdmin && accounts && <AdminUsageInsights accounts={accounts} />}
-          {isAdmin && <AccountRegistrationForm />}
-        </div>
-      </section>
+        </section>
+      )}
     </main>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,86 +23,53 @@ export default function HomePage() {
     );
   }
 
-  const highlights = [
-    {
-      title: "Status rápido",
-      caption: "Reservas",
-      accent: "from-brand-teal/70 via-brand-mint/40 to-transparent"
-    },
-    {
-      title: "Equipe alinhada",
-      caption: "Fluxos",
-      accent: "from-brand-amber/60 via-brand-terracotta/30 to-transparent"
-    },
-    {
-      title: "Segurança nativa",
-      caption: "Acessos",
-      accent: "from-brand-leaf/60 via-brand-lime/30 to-transparent"
-    }
-  ];
-
-  const chips = ["Visual limpo", "Gestão ágil", "BrowserStack"];
-
   return (
-    <main className="relative isolate flex min-h-screen flex-col justify-center overflow-hidden px-6 py-16 sm:px-10 lg:px-16">
-      <div className="pointer-events-none absolute inset-0 -z-30 bg-soft-grid opacity-40 [mask-image:radial-gradient(ellipse_at_center,rgba(0,0,0,0.85)_0%,transparent_70%)]" />
-      <div className="absolute -top-24 left-1/2 -z-20 h-96 w-96 -translate-x-1/2 rounded-full bg-brand-mint/25 blur-3xl" />
-      <div className="mx-auto grid w-full max-w-5xl gap-12 lg:grid-cols-[1fr_auto] lg:items-center">
-        <header className="space-y-8">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2 rounded-full border border-border/60 bg-surface/80 px-4 py-2 text-[0.7rem] font-semibold uppercase tracking-[0.4em] text-muted shadow-sm backdrop-blur">
-              <span className="h-2 w-2 rounded-full bg-brand-teal" />
+    <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-slate-950/5 px-4 py-12">
+      <div className="pointer-events-none absolute inset-0 -z-30 bg-soft-grid opacity-40 [mask-image:radial-gradient(circle_at_center,rgba(0,0,0,0.92)_0%,transparent_70%)]" />
+      <div className="absolute -top-32 left-1/2 -z-20 h-[28rem] w-[28rem] -translate-x-1/2 rounded-full bg-brand-mint/20 blur-3xl" />
+      <div className="absolute bottom-0 right-0 -z-10 h-64 w-64 translate-x-1/3 translate-y-1/3 rounded-full bg-brand-amber/10 blur-3xl" />
+      <div className="grid w-full max-w-4xl overflow-hidden rounded-3xl border border-border/40 bg-surface/80 shadow-2xl backdrop-blur-xl md:grid-cols-[1.1fr,1fr]">
+        <aside className="relative hidden flex-col justify-between bg-gradient-to-br from-brand-teal via-brand-mint to-brand-lime p-8 text-white md:flex">
+          <div className="space-y-6">
+            <span className="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.4em] text-white/80">
+              <span className="h-2 w-2 rounded-full bg-white" />
               QA Manager
+            </span>
+            <div className="space-y-4">
+              <h1 className="text-3xl font-semibold leading-tight">Controle compacto das contas BrowserStack</h1>
+              <p className="text-sm text-white/80">
+                Visão rápida do status das licenças e fluxo de reserva/desbloqueio com poucos cliques. Segurança e rastreabilidade para o time de QA.
+              </p>
             </div>
           </div>
-
-          <div className="space-y-4 text-balance">
-            <h1 className="text-4xl font-semibold text-foreground sm:text-5xl">Operação limpa, foco no teste</h1>
-            <p className="max-w-xl text-base text-muted">
-              Tudo o que importa para controlar reservas BrowserStack com clareza imediata.
+          <ul className="space-y-3 text-sm text-white/80">
+            <li className="flex items-center gap-2">
+              <span className="h-1.5 w-1.5 rounded-full bg-white" /> Status ao vivo das contas
+            </li>
+            <li className="flex items-center gap-2">
+              <span className="h-1.5 w-1.5 rounded-full bg-white" /> Histórico de uso centralizado
+            </li>
+            <li className="flex items-center gap-2">
+              <span className="h-1.5 w-1.5 rounded-full bg-white" /> Reservas em um toque
+            </li>
+          </ul>
+        </aside>
+        <section className="flex flex-col gap-8 p-8 sm:p-10">
+          <header className="space-y-3 text-center md:text-left">
+            <span className="inline-flex items-center justify-center gap-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-brand-teal">
+              Acesso seguro
+            </span>
+            <h2 className="text-2xl font-semibold text-foreground">Entre no painel</h2>
+            <p className="text-sm text-muted">
+              Utilize seu e-mail corporativo Quality Digital para liberar o dashboard.
             </p>
+          </header>
+          <div className="rounded-2xl border border-border/60 bg-white/70 p-6 shadow-lg shadow-brand-teal/5">
+            <LoginForm />
           </div>
-
-          <div className="flex flex-wrap gap-2 text-xs text-muted">
-            {chips.map((chip) => (
-              <span
-                key={chip}
-                className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-surface-elevated/80 px-4 py-2 font-medium text-foreground/80 shadow-sm"
-              >
-                <span className="h-1.5 w-1.5 rounded-full bg-brand-mint" />
-                {chip}
-              </span>
-            ))}
-          </div>
-
-          <section className="grid gap-4 sm:grid-cols-3">
-            {highlights.map((item) => (
-              <article
-                key={item.title}
-                className="relative overflow-hidden rounded-2xl border border-border/60 bg-surface/90 p-5 shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
-              >
-                <div className={`absolute inset-0 -z-10 bg-gradient-to-br ${item.accent}`} aria-hidden="true" />
-                <p className="text-xs uppercase tracking-[0.3em] text-muted">{item.caption}</p>
-                <h2 className="mt-3 text-lg font-semibold text-foreground">{item.title}</h2>
-              </article>
-            ))}
-          </section>
-        </header>
-
-        <section className="relative">
-          <div className="absolute inset-0 -z-10 rounded-3xl bg-gradient-to-br from-brand-teal/30 via-brand-mint/20 to-brand-amber/20 blur-2xl" aria-hidden="true" />
-          <div className="relative w-full rounded-3xl border border-border/60 bg-surface/90 p-8 shadow-2xl shadow-brand-teal/10 backdrop-blur-xl">
-            <div className="space-y-3 text-center">
-              <span className="inline-flex items-center justify-center gap-2 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-brand-teal">
-                Entrar
-              </span>
-              <h2 className="text-2xl font-semibold text-foreground">Painel QA</h2>
-              <p className="text-sm text-muted">Acesso rápido e seguro.</p>
-            </div>
-            <div className="mt-8">
-              <LoginForm />
-            </div>
-          </div>
+          <p className="text-center text-[0.75rem] text-muted md:text-left">
+            Dica: cadastre-se uma vez para validar o e-mail. Depois é só entrar com a mesma senha.
+          </p>
         </section>
       </div>
     </main>

--- a/components/dashboard/AccountList.tsx
+++ b/components/dashboard/AccountList.tsx
@@ -1,14 +1,43 @@
 "use client";
 
-import type { Account } from "@/lib/types";
+import { useMemo, useState } from "react";
+import clsx from "clsx";
+
+import { PrimaryButton } from "@/components/ui/PrimaryButton";
+import { TextInput } from "@/components/ui/TextInput";
+import { deleteAccount, updateAccount } from "@/lib/firestore";
+import type { Account, AccountStatus, UserRole } from "@/lib/types";
 
 interface AccountListProps {
   accounts: Account[];
   isLoading: boolean;
   error: Error | null;
+  role?: UserRole | null;
 }
 
-export function AccountList({ accounts, isLoading, error }: AccountListProps) {
+interface EditableAccountState {
+  username: string;
+  email: string;
+  password: string;
+  status: AccountStatus;
+}
+
+type AccountFeedback =
+  | { type: "success"; message: string }
+  | { type: "error"; message: string };
+
+export function AccountList({ accounts, isLoading, error, role }: AccountListProps) {
+  const isAdmin = role === "admin";
+  const [editingAccountId, setEditingAccountId] = useState<string | null>(null);
+  const [formState, setFormState] = useState<EditableAccountState | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [feedbackMap, setFeedbackMap] = useState<Record<string, AccountFeedback>>({});
+
+  const orderedAccounts = useMemo(() => {
+    return [...accounts].sort((a, b) => a.username.localeCompare(b.username));
+  }, [accounts]);
+
   if (isLoading) {
     return <p className="text-sm text-slate-500">Carregando contas...</p>;
   }
@@ -25,28 +54,278 @@ export function AccountList({ accounts, isLoading, error }: AccountListProps) {
     return <p className="text-sm text-slate-500">Nenhuma conta encontrada.</p>;
   }
 
+  const resetFeedback = (accountId: string) => {
+    setFeedbackMap((previous) => {
+      const { [accountId]: _removed, ...rest } = previous;
+      return rest;
+    });
+  };
+
+  const handleEditStart = (account: Account) => {
+    resetFeedback(account.id);
+    setEditingAccountId(account.id);
+    setFormState({
+      username: account.username,
+      email: account.email,
+      password: "",
+      status: account.status,
+    });
+  };
+
+  const handleEditCancel = () => {
+    setEditingAccountId(null);
+    setFormState(null);
+  };
+
+  const handleEditSubmit = async () => {
+    if (!editingAccountId || !formState) return;
+    setSaving(true);
+    resetFeedback(editingAccountId);
+    try {
+      const payload: {
+        username: string;
+        email: string;
+        status: AccountStatus;
+        password?: string | null;
+      } = {
+        username: formState.username.trim(),
+        email: formState.email.trim(),
+        status: formState.status,
+      };
+
+      const passwordValue = formState.password.trim();
+      if (passwordValue) {
+        payload.password = passwordValue;
+      }
+
+      await updateAccount(editingAccountId, payload);
+      setFeedbackMap((previous) => ({
+        ...previous,
+        [editingAccountId]: {
+          type: "success",
+          message: "Conta atualizada com sucesso.",
+        },
+      }));
+      setEditingAccountId(null);
+      setFormState(null);
+    } catch (err) {
+      setFeedbackMap((previous) => ({
+        ...previous,
+        [editingAccountId]: {
+          type: "error",
+          message:
+            (err as Error).message ?? "Não foi possível atualizar a conta.",
+        },
+      }));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (accountId: string, username: string) => {
+    resetFeedback(accountId);
+    const confirmationMessage = `Deseja realmente excluir a conta ${username}? Esta ação não pode ser desfeita.`;
+    if (typeof window !== "undefined" && !window.confirm(confirmationMessage)) {
+      return;
+    }
+    setDeletingId(accountId);
+    try {
+      await deleteAccount(accountId);
+      setFeedbackMap((previous) => ({
+        ...previous,
+        [accountId]: {
+          type: "success",
+          message: "Conta removida.",
+        },
+      }));
+    } catch (err) {
+      setFeedbackMap((previous) => ({
+        ...previous,
+        [accountId]: {
+          type: "error",
+          message: (err as Error).message ?? "Não foi possível excluir a conta.",
+        },
+      }));
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
   return (
     <ul className="space-y-3">
-      {accounts.map((account) => {
+      {orderedAccounts.map((account) => {
         const isBusy = account.status === "busy";
+        const isEditing = editingAccountId === account.id;
+        const feedback = feedbackMap[account.id];
+
+        if (isAdmin && isEditing && formState) {
+          return (
+            <li
+              key={account.id}
+              className="space-y-3 rounded-xl border border-slate-200 bg-white p-5 shadow-sm"
+            >
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-semibold text-slate-900">
+                  Editar conta
+                </h3>
+                <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
+                  ID: {account.username}
+                </span>
+              </div>
+              <div className="space-y-3">
+                <TextInput
+                  label="Usuário"
+                  value={formState.username}
+                  onChange={(event) =>
+                    setFormState((previous) =>
+                      previous
+                        ? { ...previous, username: event.target.value }
+                        : previous,
+                    )
+                  }
+                  placeholder="qa-team"
+                  required
+                />
+                <TextInput
+                  label="E-mail"
+                  type="email"
+                  value={formState.email}
+                  onChange={(event) =>
+                    setFormState((previous) =>
+                      previous
+                        ? { ...previous, email: event.target.value }
+                        : previous,
+                    )
+                  }
+                  placeholder="conta@empresa.com"
+                  required
+                />
+                <TextInput
+                  label="Atualizar senha"
+                  type="text"
+                  value={formState.password}
+                  onChange={(event) =>
+                    setFormState((previous) =>
+                      previous
+                        ? { ...previous, password: event.target.value }
+                        : previous,
+                    )
+                  }
+                  placeholder="Opcional — mantém senha atual se em branco"
+                />
+                <label className="block space-y-1 text-sm text-slate-600">
+                  <span className="font-medium text-slate-700">Status</span>
+                  <select
+                    value={formState.status}
+                    onChange={(event) =>
+                      setFormState((previous) =>
+                        previous
+                          ? {
+                              ...previous,
+                              status: event.target.value as AccountStatus,
+                            }
+                          : previous,
+                      )
+                    }
+                    className="w-full rounded-xl border border-slate-200 bg-slate-50 px-3.5 py-2.5 text-sm font-medium text-slate-700 shadow-sm focus:border-brand-teal focus:outline-none focus:ring-4 focus:ring-brand-teal/20"
+                  >
+                    <option value="free">Livre</option>
+                    <option value="busy">Em uso</option>
+                  </select>
+                </label>
+                <div className="flex flex-wrap gap-2">
+                  <PrimaryButton
+                    type="button"
+                    onClick={handleEditSubmit}
+                    disabled={saving}
+                  >
+                    {saving ? "Salvando..." : "Salvar alterações"}
+                  </PrimaryButton>
+                  <button
+                    type="button"
+                    onClick={handleEditCancel}
+                    className="rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-300 hover:text-slate-700"
+                  >
+                    Cancelar
+                  </button>
+                </div>
+                {feedback && (
+                  <p
+                    className={clsx(
+                      "text-xs",
+                      feedback.type === "success"
+                        ? "text-emerald-700"
+                        : "text-rose-600",
+                    )}
+                  >
+                    {feedback.message}
+                  </p>
+                )}
+              </div>
+            </li>
+          );
+        }
+
         return (
           <li
             key={account.id}
-            className="flex items-center justify-between rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+            className="space-y-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
           >
-            <div>
-              <p className="font-semibold text-slate-900">{account.username}</p>
-              <p className="text-xs text-slate-500">{account.email}</p>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-1">
+                <p className="font-semibold text-slate-900">
+                  {account.username}
+                </p>
+                <p className="text-xs text-slate-500">{account.email}</p>
+                {account.password && (
+                  <p className="font-mono text-xs text-slate-500">
+                    Senha: {account.password}
+                  </p>
+                )}
+              </div>
+              <span
+                className={clsx(
+                  "inline-flex h-fit items-center rounded-full px-3 py-1 text-xs font-semibold",
+                  isBusy
+                    ? "bg-amber-100 text-amber-700"
+                    : "bg-emerald-100 text-emerald-700",
+                )}
+              >
+                {isBusy ? "Em uso" : "Livre"}
+              </span>
             </div>
-            <span
-              className={`rounded-full px-3 py-1 text-xs font-semibold ${
-                isBusy
-                  ? "bg-amber-100 text-amber-700"
-                  : "bg-emerald-100 text-emerald-700"
-              }`}
-            >
-              {isBusy ? "Em uso" : "Livre"}
-            </span>
+
+            {isAdmin && (
+              <div className="flex flex-wrap gap-2 text-xs font-medium">
+                <button
+                  type="button"
+                  onClick={() => handleEditStart(account)}
+                  className="rounded-lg border border-slate-200 px-3 py-2 text-slate-600 transition hover:border-slate-300 hover:text-slate-800"
+                >
+                  Editar
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleDelete(account.id, account.username)}
+                  disabled={deletingId === account.id}
+                  className="rounded-lg border border-rose-200 px-3 py-2 text-rose-600 transition hover:border-rose-300 hover:text-rose-700 disabled:cursor-not-allowed disabled:opacity-70"
+                >
+                  {deletingId === account.id ? "Removendo..." : "Excluir"}
+                </button>
+                {feedback && (
+                  <span
+                    className={clsx(
+                      "self-center",
+                      feedback.type === "success"
+                        ? "text-emerald-700"
+                        : "text-rose-600",
+                    )}
+                  >
+                    {feedback.message}
+                  </span>
+                )}
+              </div>
+            )}
           </li>
         );
       })}


### PR DESCRIPTION
## Summary
- redesign the login screen with a compact two-column layout and streamlined messaging
- move the quick reservation card to the top of the user dashboard and tailor layouts for admins vs. collaborators
- enable admins to edit and delete BrowserStack accounts through new Firestore helpers and inline forms

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd102503c88327a93043e3294f1c02